### PR TITLE
Feature/fix birthday clients signup

### DIFF
--- a/src/app/code/local/SPM/ShopyMind/Test/Lib/ShopymindClient/Callback/GetBirthdayClientsSignup.php
+++ b/src/app/code/local/SPM/ShopyMind/Test/Lib/ShopymindClient/Callback/GetBirthdayClientsSignup.php
@@ -7,19 +7,25 @@ class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup e
 {
     public function testGetBirthdayClientsSignupShoulReturnEmptyIfNoCustomersMatchFilters()
     {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array());
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-11-21 12:34:56', array());
         $this->assertEmpty($results);
     }
 
-    public function testGetBirthdayClientsSignupShoulReturnClientWhichCreateTheirAccountAtDateReference() {
+    public function testGetBirthdayClientsSignupShouldNotReturnClientWhoCreatedTheirAccountAtDateReference()
+    {
         $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array());
+        $this->assertEmpty($results);
+    }
 
+    public function testGetBirthdayClientsSignupShouldReturnCustomersWhoCreatedTheirAccountOneYearAgo()
+    {
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array());
         $expected = array('1', '3', '4');
         $this->assertCustomerIdsEquals($expected, $results);
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectCountry() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array(
             array('country' => 'US')
         ));
 
@@ -28,7 +34,7 @@ class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup e
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectCountryAndRegion() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array(
             array('country' => 'US', 'region' => 'AL')
         ));
 
@@ -37,7 +43,7 @@ class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup e
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectRegion() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array(
             array('region' => 'AL')
         ));
 
@@ -46,7 +52,7 @@ class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup e
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectRegionsAndCountries() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array(
             array('country' => 'US', 'region' => 'AL'),
             array('country' => 'FR')
         ));
@@ -56,14 +62,14 @@ class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup e
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientCountCorrespondingToFilters() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(), true);
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array(), true);
 
         $expected = 3;
         $this->assertEquals($expected, $results['count']);
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientAccordingToScope() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp('store-2', '2014-10-27 12:34:56', array());
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp('store-2', '2015-10-27 12:34:56', array());
 
         $expected = array('5');
         $this->assertCustomerIdsEquals($expected, $results);

--- a/src/app/code/local/SPM/ShopyMind/Test/Lib/ShopymindClient/Callback/GetBirthdayClientsSignup.php
+++ b/src/app/code/local/SPM/ShopyMind/Test/Lib/ShopymindClient/Callback/GetBirthdayClientsSignup.php
@@ -5,9 +5,9 @@
  */
 class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup extends EcomDev_PHPUnit_Test_Case
 {
-    public function testGetBirthdayClientsSignupShoulReturnEmptyIfNoCustomersMatchFilters() {
+    public function testGetBirthdayClientsSignupShoulReturnEmptyIfNoCustomersMatchFilters()
+    {
         $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2015-10-21 12:34:56', array());
-
         $this->assertEmpty($results);
     }
 
@@ -19,28 +19,37 @@ class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup e
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectCountry() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(array('country' => 'US')));
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+            array('country' => 'US')
+        ));
 
         $expected = array('3', '4');
         $this->assertCustomerIdsEquals($expected, $results);
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectCountryAndRegion() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(array('country' => 'US', 'region' => 'AL')));
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+            array('country' => 'US', 'region' => 'AL')
+        ));
 
         $expected = array('3');
         $this->assertCustomerIdsEquals($expected, $results);
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectRegion() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(array('region' => 'AL')));
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+            array('region' => 'AL')
+        ));
 
         $expected = array('3');
         $this->assertCustomerIdsEquals($expected, $results);
     }
 
     public function testGetBirthdayClientsSignupShoulReturnClientInCorrectRegionsAndCountries() {
-        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(array('country' => 'US', 'region' => 'AL'), array('country' => 'FR')));
+        $results = ShopymindClient_Callback::getBirthdayClientsSignUp(false, '2014-10-21 12:34:56', array(
+            array('country' => 'US', 'region' => 'AL'),
+            array('country' => 'FR')
+        ));
 
         $expected = array('3');
         $this->assertCustomerIdsEquals($expected, $results);
@@ -61,7 +70,10 @@ class SPM_ShopyMind_Test_Lib_ShopymindClient_Callback_GetBirthdayClientsSignup e
     }
 
     private function assertCustomerIdsEquals($expected, $results) {
-        $customerIds = array_map(function($customer) { return $customer['customer']['id_customer']; }, $results);
+        $customerIds = array_map(
+            function($customer) { return $customer['customer']['id_customer']; },
+            $results
+        );
         $this->assertEquals($expected, $customerIds);
     }
 }

--- a/src/lib/ShopymindClient/Callback.php
+++ b/src/lib/ShopymindClient/Callback.php
@@ -356,7 +356,7 @@ class ShopymindClient_Callback {
      * Retrieve customer which have their signup anniversary corresponding to $dateReference
      *
      * @param int $storeId
-     * @param string $dateReference
+     * @param string $dateReference usually today's date. The date used to determine the signup birthday (only the day / month are useful)
      * @param array $timezones
      * @param bool $justCount
      *
@@ -373,11 +373,8 @@ class ShopymindClient_Callback {
 
         $customerCollection = Mage::getModel('customer/customer')
             ->getCollection()
-            ->addFieldToFilter('created_at', array(
-                'date' => true,
-                'from' => date('Y-m-d', strtotime($dateReference)),
-                'to' =>  date('Y-m-d', strtotime($dateReference . ' + 1 day'))
-            ))
+            ->addFieldToFilter('created_at', array('like' => date('%-m-d%', strtotime($dateReference))))
+            ->addFieldToFilter('created_at', array('nlike' => date('Y-m-d%', strtotime($dateReference))))
             ->addAttributeToSelect('entity_id');
 
         SPM_ShopyMind_Model_Scope::fromShopymindId($storeId)->restrictCollection($customerCollection);

--- a/src/lib/ShopymindClient/Callback.php
+++ b/src/lib/ShopymindClient/Callback.php
@@ -371,37 +371,35 @@ class ShopymindClient_Callback {
             ), func_get_args());
         }
 
-        $scope = SPM_ShopyMind_Model_Scope::fromShopymindId($storeId);
-
         $customerCollection = Mage::getModel('customer/customer')
             ->getCollection()
-            ->addFieldToFilter('created_at', array('date' => true, 'from' => date('Y-m-d', strtotime($dateReference)), 'to' =>  date('Y-m-d', strtotime($dateReference . ' + 1 day'))))
+            ->addFieldToFilter('created_at', array(
+                'date' => true,
+                'from' => date('Y-m-d', strtotime($dateReference)),
+                'to' =>  date('Y-m-d', strtotime($dateReference . ' + 1 day'))
+            ))
             ->addAttributeToSelect('entity_id');
-        $scope->restrictCollection($customerCollection);
+
+        SPM_ShopyMind_Model_Scope::fromShopymindId($storeId)->restrictCollection($customerCollection);
 
         if (!empty($timezones)) {
             $customerCollection->joinAttribute('customer_country_id', 'customer_address/country_id', 'default_billing');
 
             $countryIds = array_map(
                 function($zone) { return $zone['country']; },
-                array_filter($timezones,
-                    function($zone) { return !empty($zone['country']); }
-                )
+                array_filter($timezones, function($zone) { return !empty($zone['country']); })
             );
-
-            $regionIds = array_map(
-                function($zone) { return $zone['region']; },
-                array_filter($timezones,
-                    function($zone) { return !empty($zone['region']); }
-                )
-            );
-
             if (!empty($countryIds)) {
                 $customerCollection->addAttributeToFilter('customer_country_id', array('in' => $countryIds));
             }
 
+            $regionIds = array_map(
+                function($zone) { return $zone['region']; },
+                array_filter($timezones, function($zone) { return !empty($zone['region']); })
+            );
             if (!empty($regionIds)) {
-                $customerCollection->joinAttribute('customer_region_id', 'customer_address/region_id', 'default_billing')
+                $customerCollection
+                    ->joinAttribute('customer_region_id', 'customer_address/region_id', 'default_billing')
                     ->joinTable('directory/country_region', 'region_id=customer_region_id', array('code'), array('code' => array('in' => $regionIds)), 'inner');
             }
 


### PR DESCRIPTION
Changed the behavior so when the reference date is passed (e.g `2015-02-12`), all customers who signed up at the same day/month at least one year ago are returned (e.g `2014-02-12`, `2010-02-12` ... but not the one at `2015-02-12`)